### PR TITLE
Format de date dd-moislong-yyyy dans le header des posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,23 @@ layout: default
 
 <h1>{{ page.title }}</h1>
 <p>
-  {{ page.date | date_to_string }} -
+{% assign month = page.date | date: "%-m" %}
+{{ page.date | date: "%-d" }}
+{% case month %}
+  {% when '1' %}janvier
+  {% when '2' %}février
+  {% when '3' %}mars
+  {% when '4' %}avril
+  {% when '5' %}mai
+  {% when '6' %}juin
+  {% when '7' %}juillet
+  {% when '8' %}août
+  {% when '9' %}septembre
+  {% when '10' %}octobre
+  {% when '11' %}novembre
+  {% when '12' %}décembre
+{% endcase %}
+{{ page.date | date: "%Y" }} -
   {% for author in authors %}
     {% assign current_author = site.authors | where: "nick", author | first %}
     {% unless forloop.first %}

--- a/docs/2020/04/18/regards-sur-un-atelier-satir.html
+++ b/docs/2020/04/18/regards-sur-un-atelier-satir.html
@@ -30,7 +30,11 @@
 
 <h1>Regards sur un atelier Satir</h1>
 <p>
-  18 Apr 2020 -
+
+18
+avril
+  
+2020 -
   
     
     


### PR DESCRIPTION
C'est hardcoder en français et ça mérite une fonction si on veut pas dupliquer tout ce code